### PR TITLE
Simplified get_wiki_text, some minor code cleanup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,14 +15,15 @@ import random
 import time
 import json
 import praw
+import praw.exceptions
 import re
 
 # Settings 
 
-msg_cache_file      = "cache/msg_cache.txt"
-cache_file          = "cache/com_cache.txt"
+msg_cache_file = "cache/msg_cache.txt"
+cache_file = "cache/com_cache.txt"
 user_blacklist_file = "user_blacklist.txt"
-bot_list_file = "bots.txt" # Currently not in use
+bot_list_file = "bots.txt"  # Currently not in use
 
 # bd_debug = False
 
@@ -40,12 +41,14 @@ user_include_done = "Done!\n\nHave a nice day!"
 user_not_excluded = "It seems you are not excluded from the bot. If you think this is false, [message](https://www.reddit.com/message/compose?to=kittens_from_space) me.\n\nHave a nice day!"
 
 footer_links = [
-                 ["PM", "https://www.reddit.com/message/compose?to=kittens_from_space"],
-                 [exclude[0], "https://reddit.com/message/compose?to=WikiTextBot&message=" + exclude[0].replace(" ", "") + "&subject=" + exclude[0].replace(" ", "")],
-                 [exclude[1], "https://np.reddit.com/r/SUBREDDITNAMEHERE/about/banned"],
-                 ["FAQ / Information", "https://np.reddit.com/r/WikiTextBot/wiki/index"],
-                 ["Source", "https://github.com/kittenswolf/WikiTextBot"]
-               ]
+    ["PM", "https://www.reddit.com/message/compose?to=kittens_from_space"],
+    [exclude[0],
+     "https://reddit.com/message/compose?to=WikiTextBot&message=" + exclude[0].replace(" ", "") + "&subject=" + exclude[
+         0].replace(" ", "")],
+    [exclude[1], "https://np.reddit.com/r/SUBREDDITNAMEHERE/about/banned"],
+    ["FAQ / Information", "https://np.reddit.com/r/WikiTextBot/wiki/index"],
+    ["Source", "https://github.com/kittenswolf/WikiTextBot"]
+]
 
 downvote_remove = "^Downvote ^to ^remove"
 
@@ -53,8 +56,10 @@ footer_seperator = "^|"
 
 normal_chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ßÄÖÜäöüàâæçèéêëîïôœùûÀÂÆÇÈÉÊËÎÏÔŒÙÛ-_#'
 disallowed_strings = ["List of", "Glossary of", "Category:", "File:", "Wikipedia:"]
-body_disallowed_strings = ["From a modification: This is a redirect from a modification of the target's title or a closely related title. For example, the words may be rearranged, or punctuation may be different.", "From a miscapitalisation: This is a redirect from a miscapitalisation. The correct form is given by the target of the redirect.", "{\displaystyle"]
-
+body_disallowed_strings = [
+    "From a modification: This is a redirect from a modification of the target's title or a closely related title. For example, the words may be rearranged, or punctuation may be different.",
+    "From a miscapitalisation: This is a redirect from a miscapitalisation. The correct form is given by the target of the redirect.",
+    "{\displaystyle"]
 
 errors_to_not_print = ["received 403 HTTP response"]
 
@@ -64,12 +69,13 @@ image_extensions = [".png", ".jpeg", ".jpg", ".bmp", ".gif"]
 intro_wikipedia_link = wikipedia_link = "https://en.wikipedia.org/w/api.php?format=json&action=query&prop=extracts&explaintext=&exintro=&exsentences=NUMHERE__1&titles="
 category_wikipedia_link = "https://en.wikipedia.org/w/api.php?action=query&format=json&prop=revisions&rvprop=content&rvsection=SECTIONHERE__1&titles="
 
-if __name__=='__main__':
+if __name__ == '__main__':
     print("Logging in..")
     reddit = praw.Reddit(user_agent='*',
                          client_id="*", client_secret="*",
                          username=bot_username, password="*")
     print("Logged in.")
+
 
 def get_thumbnail(input_id):
     # Currently not used
@@ -87,7 +93,6 @@ def get_thumbnail(input_id):
             if extension.lower() in end_part:
                 good_images.append(url)
 
-
     split_word = page_title.split("_")
 
     thumbnail_images = []
@@ -95,9 +100,7 @@ def get_thumbnail(input_id):
         for url in good_images:
             for word in split_word:
                 if word.lower() in url.lower():
-
                     thumbnail_images.append(url)
-
 
         if thumbnail_images:
             thumbnail = random.choice(thumbnail_images)
@@ -108,8 +111,10 @@ def get_thumbnail(input_id):
 
     return thumbnail
 
+
 def replace_right(source, target, replacement, replacements=None):
     return replacement.join(source.rsplit(target, replacements))
+
 
 def get_cache(file):
     """Gets the cache from $file and clears to len(comment_threshold) if necesarry. Also saves it after."""
@@ -126,15 +131,16 @@ def get_cache(file):
     """Trims the file if it goes over maximum threshold"""
     # Currently done manually... dont ask why.
     # if len(real_cache) > comment_threshold:
-        # last_part = real_cache[-limit:]
+    # last_part = real_cache[-limit:]
 
-        # with open(file, "w") as f:
-            # for id in last_part:
-                # f.write(id + "\n")
+    # with open(file, "w") as f:
+    # for id in last_part:
+    # f.write(id + "\n")
 
-        # real_cache = last_part
+    # real_cache = last_part
 
     return real_cache
+
 
 def input_cache(file, input):
     try:
@@ -144,16 +150,18 @@ def input_cache(file, input):
         print(e)
         return
 
+
 def locateByName(e, name):
-    if e.get('name',None) == name:
+    if e.get('name', None) == name:
         return e
 
-    for child in e.get('children',[]):
-        result = locateByName(child,name)
+    for child in e.get('children', []):
+        result = locateByName(child, name)
         if result is not None:
             return result
 
     return None
+
 
 def get_wikipedia_links(input_text):
     """Gets en.wikipedia.org link in input_text. If it can't be found, returns []"""
@@ -182,6 +190,7 @@ def get_wikipedia_links(input_text):
     soup.decompose()
 
     return fixed_urls
+
 
 def get_wiki_text(original_link):
     try:
@@ -213,6 +222,7 @@ def get_wiki_text(original_link):
         print(str(e))
         return 'Error'
 
+
 def generate_footer():
     footer = "^[ "
 
@@ -233,9 +243,10 @@ def generate_footer():
 
     return footer
 
+
 def generate_comment(input_urls):
-    comment      = []
-    content      = []
+    comment = []
+    content = []
     done_comment = []
 
     for url in input_urls:
@@ -243,7 +254,6 @@ def generate_comment(input_urls):
 
         if url_content != "Error":
             content.append(url_content)
-
 
     for chunk in content:
         title, body = chunk
@@ -265,6 +275,7 @@ def generate_comment(input_urls):
 
     return comment
 
+
 def check_excluded(file, input_user):
     try:
         with open(file) as f:
@@ -277,9 +288,11 @@ def check_excluded(file, input_user):
 
     return input_user.lower() in current_excluded
 
+
 def excludeUser(file, input_user):
     with open(file, 'a') as f:
         f.write(input_user + '\n')
+
 
 def includeUser(file, input_user):
     try:
@@ -294,6 +307,7 @@ def includeUser(file, input_user):
     with open(file, "w") as f:
         for user in current_excluded:
             f.write(user + "\n")
+
 
 def monitorMessages():
     """Montors the newest 100 messages and excludes/includes users requesting it."""
@@ -326,12 +340,11 @@ def monitorMessages():
                     else:
                         message.reply(user_not_excluded)
 
-
             input_cache(msg_cache_file, message.id)
 
-def enter_bot(file, input_user):
-    return #Not in use
 
+def enter_bot(file, input_user):
+    return  # Not in use
 
     """Enter a user as a bot to $file"""
     try:
@@ -347,10 +360,10 @@ def enter_bot(file, input_user):
         for bot in current_bots:
             f.write(bot + "\n")
 
+
 def get_bot_list(file):
     # Currently not used. Maybe soon?
     return ["HelperBot_", "AutoModerator", "MovieGuide", "Decronym"]
-
 
     try:
         raw_file = open(file, "r").read()
@@ -361,6 +374,7 @@ def get_bot_list(file):
     bots = [bot for bot in raw_file.split("\n") if not bot == '']
     return bots
 
+
 def check_bot(input_user):
     # Currently not used
     return "-"
@@ -368,16 +382,17 @@ def check_bot(input_user):
     # score = bd.calc_bot_score(input_user)
 
     # if not score == "Error":
-        # verdict = bd.score_helper(score)
-        # return verdict
+    # verdict = bd.score_helper(score)
+    # return verdict
     # else:
-        # return "-"
+    # return "-"
+
 
 def main():
     monitorMessages()
     for comment in reddit.subreddit('all').comments(limit=100):
 
-        #Check if "wikipedia.org/wiki/" in comment. This should migate most comment.id spam
+        # Check if "wikipedia.org/wiki/" in comment. This should migate most comment.id spam
         if "wikipedia.org/wiki/" in str(comment.body).lower():
             # Check if user is blacklisted (excluded)
             if not check_excluded(user_blacklist_file, str(comment.author)) == True:
@@ -404,8 +419,8 @@ def main():
                                     # print(comment_text)
                                     comment.reply(comment_text)
 
-
                 input_cache(cache_file, comment.id)
+
 
 if __name__ == '__main__':
     # bd.settings(reddit, debug_in=bd_debug)
@@ -413,16 +428,10 @@ if __name__ == '__main__':
     while True:
         try:
             main()
-        except Exception as e:
-            if e == praw.exceptions.APIException:
-                print("ratelimit hit, sleeping 100 secs.")
-                time.sleep(100)
-
-            if not str(e) in errors_to_not_print:
-                print(str(e))
-
-                # traceback.print_exc()
-
-
             time.sleep(0.5)
-
+        except praw.exceptions.APIException as e:
+            print('ratelimit hit, sleeping 100 secs.')
+            time.sleep(100)
+        except Exception as e:
+            if str(e) not in errors_to_not_print:
+                print(e)


### PR DESCRIPTION
The main change is to simplify `get_wiki_text` to only use the `wikipedia` module. `wikipedia` doesn't allow specifying a sentence cutoff, so instead it breaks after the first paragraph. I also added some pep8 changes that I thought improve readability.

I also made some of the loops and conditionals more idiomatic. All of these should be equivalent to what's currently in use, but I wasn't able to test some of them without an account - particularly the changes dealing with file I/O.