### PR TITLE
Fix to footer on new reddit and mobile

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -218,7 +218,7 @@ class generate_comment:
         """
         Rather than placing a ^ before every word, we can wrap the entire post in ^(...), to get a more consistent and professional footer.
         """
-        return "^([ " + " | ".join(["[" + link[0] + "](" + link[1] + ")" for link in footer_links]) + " ] Downvote to remove | v0.28)"
+        return "^([ )" + "^( | )".join(["[^(" + link[0] + ")](" + link[1] + ")" for link in footer_links]) + "^( ] Downvote to remove | v0.28)"
 
     def generate_comment(input_urls, comment_text=None):
         comment      = []

--- a/bot.py
+++ b/bot.py
@@ -379,7 +379,7 @@ def main():
     for comment in reddit.subreddit('all').comments(limit=100):
         parse_comment(comment)
 
-breakpoint()
+
 while True:
     try:
         main()

--- a/bot.py
+++ b/bot.py
@@ -45,9 +45,6 @@ footer_links = [
                  ["Donate", "https://www.reddit.com/r/WikiTextBot/wiki/donate"]
                ]
                
-downvote_remove = "^Downvote ^to ^remove"
-               
-footer_seperator = "^|"
 
 disallowed_strings = ["List of", "Glossary of", "Category:", "File:", "Wikipedia:"]
 body_disallowed_strings = ["From a modification: This is a redirect from a modification of the target's title or a closely related title. For example, the words may be rearranged, or punctuation may be different.", "From a miscapitalisation: This is a redirect from a miscapitalisation. The correct form is given by the target of the redirect.", "{\displaystyle"]
@@ -66,9 +63,6 @@ reddit = praw.Reddit(user_agent='*',
 logger.log(type="INFO", message="Logged in.")
 
 bot_detector.settings(reddit, False)
-
-def replace_right(source, target, replacement, replacements=None):
-    return replacement.join(source.rsplit(target, replacements))
 
 def get_cache(file):
     """Gets the cache from $file and clears to len(comment_threshold) if necesarry. Also saves it after."""
@@ -219,26 +213,12 @@ def get_wiki_text(original_link):
        
 class generate_comment:
        
-    @functools.lru_cache(maxsize=10)       
+    @functools.lru_cache(maxsize=10)
     def generate_footer():
-        footer = "^[ "
-
-        links = []
-        for link in footer_links:
-            final_desc = "^" + link[0].replace(" ", " ^")
-            final_link = "[" + final_desc + "](" + link[1] + ")"
-            links.append(final_link)
-
-        for link in links:
-            footer += link
-            footer += " " + footer_seperator + " "
-
-        footer += " ^]"
-        footer = replace_right(footer, footer_seperator, "", 1)
-    
-        footer += "\n" + downvote_remove + " ^| ^v0.28"
-
-        return footer
+        """
+        Rather than placing a ^ before every word, we can wrap the entire post in ^(...), to get a more consistent and professional footer.
+        """
+        return "^([ " + " | ".join(["[" + link[0] + "](" + link[1] + ")" for link in footer_links]) + " ] Downvote to remove | v0.28)"
 
     def generate_comment(input_urls, comment_text=None):
         comment      = []
@@ -399,7 +379,7 @@ def main():
     for comment in reddit.subreddit('all').comments(limit=100):
         parse_comment(comment)
 
-
+breakpoint()
 while True:
     try:
         main()


### PR DESCRIPTION
Hallo Kittens,

I recently learned some more about reddit's `^`, which allows the comments posted by this bot to be slightly prettier **in the new version of reddit.**
Note, these issues do not seem to exist on the old design of reddit, which is likely why they've gone unnoticed for a while.

# Description

I ran across this comment posted by what appears to be your bot.
![image](https://user-images.githubusercontent.com/37621491/74965130-ef5ab600-5414-11ea-8ff6-a8b48ed79834.png)
at https://new.reddit.com/r/latterdaysaints/comments/f6utek/would_the_15_apostles_allowing_homosexual/fi78qag/?utm_source=share&utm_medium=web2x
I noticed the iffy footer, and figured I could try to help make this look more professional. Note that the footer looks as intended in old reddit: https://old.reddit.com/r/latterdaysaints/comments/f6utek/would_the_15_apostles_allowing_homosexual/fi78qag/?utm_source=share&utm_medium=web2x

There are essentially two main problems, which can both be solved. As you know, the code used in the actual comment is the following: `^[ [^PM](https://www.reddit.com/message/compose?to=kittens_from_space) ^| [^Exclude ^me](https://reddit.com/message/compose?to=WikiTextBot&message=Excludeme&subject=Excludeme) ^| [^Exclude ^from ^subreddit](https://np.reddit.com/r/SUBREDDITNAMEHERE/about/banned) ^| [^FAQ ^/ ^Information](https://np.reddit.com/r/WikiTextBot/wiki/index) ^| [^Source](https://github.com/kittenswolf/WikiTextBot) ^| [^Donate](https://www.reddit.com/r/WikiTextBot/wiki/donate) ^] ^Downvote ^to ^remove ^| ^v0.28`.

## Problem 1
The `^PM`, `^me` etc. is not reduced in size. Moreso, the `^` is still visible within the message. This can be resolved by placing a space inbetween `^PM` and the `]`, as the space is used by the `^` to be sure that a word has ended.

## Problem 2
Between all words of the sentence that make up the link, there are small blue lines at the "normal" height. This causes the link to look a bit funky. This too can be resolved. We can use brackets after the `^` to move text up as a group, rather than per word:
`[^(Exclude from Subreddit)](https://www.example.com)` will produce a clean link.

## After applying the Fix shown in Problem 2
The following image shows the current situation **in new reddit**, after applying a fix for problem 2, followed by a copy of the markdown that was used:
![image](https://user-images.githubusercontent.com/37621491/74965873-444afc00-5416-11ea-8492-b677d6b291c9.png)
This can be experienced on new reddit at the following link: https://new.reddit.com/r/test/comments/f6w19c/test/ **(Note: the "The Final Fix" is what is implemented in this pull request)**
To see the results in old reddit, visit this link: https://old.reddit.com/r/test/comments/f6w19c/test/   
You can browse to the post in mobile too, to experience it there.

# How to reproduce
You can browse to https://new.reddit.com/r/latterdaysaints/comments/f6utek/would_the_15_apostles_allowing_homosexual/fi78qag/?utm_source=share&utm_medium=web2x to experience the iffy footer posted by your bot account yourself.

# What now?
You can, if you wish, perform some testing on the new function, and investigate whether the produced string is as intended, if you wish to be sure that the new string is proper.   
The new footer seems to show correctly for me for old reddit, new reddit, reddit mobile and RIF (reddit is fun, a mobile app for reddit)

---

Good job on this bot! It has been quite useful in the past.